### PR TITLE
remove object spread operator for Edge compat

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -34,10 +34,9 @@ const create = algorithm => async (buffer, options) => {
 		buffer = new _globalThis.TextEncoder().encode(buffer);
 	}
 
-	options = {
-		outputFormat: 'hex',
-		...options
-	};
+	options = Object.assign({
+		outputFormat: 'hex'
+	}, options);
 
 	const hash = await _globalThis.crypto.subtle.digest(algorithm, buffer);
 


### PR DESCRIPTION
Microsoft Edge doesn't support object spread yet, so I had to replace it with an Object.assign for my use case. What do you think?