### PR TITLE
Update index.js to add more hashing formats to the library

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'crypto-hash';

--- a/index.js
+++ b/index.js
@@ -17,7 +17,14 @@ const create = algorithm => async (buffer, options) => {
 	return hash.digest().buffer;
 };
 
+exports.ripemd160 = create('ripemd160');
+exports.blake32s256 = create('blake32s256');
+exports.blake32b512 = create('blake32b512');
+exports.md4 = create('md4');
+exports.md5 = create('md5');
 exports.sha1 = create('sha1');
+exports.sha224 = create('sha224');
 exports.sha256 = create('sha256');
 exports.sha384 = create('sha384');
 exports.sha512 = create('sha512');
+exports.whirlpool = create('whirlpool');

--- a/readme.md
+++ b/readme.md
@@ -34,10 +34,17 @@ const {sha256} = require('crypto-hash');
 
 ## API
 
+### ripemd160(input, [options])
+### blake32s256(input, [options])
+### blake32b512(input, [options])
+### md4(input, [options])
+### md5(input, [options])
 ### sha1(input, [options])
+### sha224(input, [options])
 ### sha256(input, [options])
 ### sha384(input, [options])
 ### sha512(input, [options])
+### whirlpool(input, [options])
 
 Returns a `Promise<string>` with a hex-encoded hash.
 


### PR DESCRIPTION
Updates index.js to add every hashing format under the sun as of version 11.12.0 of node and this comment (MD4, MD5, SHA224, RIPEMD160, BLAKE32s256, BLAKE32b512, and Whirlpool were added).