### PR TITLE
Move hashing to worker thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
   - '10'
-  - '8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - '10'
+  - '11'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - '11'
+  - '12'
+  - '10'
+  - '8'

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const requireOptional = (name, defaultValue) => {
 	try {
 		return require(name);
-	} catch (error) {
+	} catch (_) {
 		return defaultValue;
 	}
 };
@@ -26,9 +26,10 @@ const createWorker = () => {
 
 		task(message.value);
 	});
-	worker.on('error', err => {
+
+	worker.on('error', error => {
 		// Any error here is effectively an equivalent of segfault and have no scope, so we just throw it on callback level
-		throw err;
+		throw error;
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 'use strict';
 const crypto = require('crypto');
 
-let Worker;
+const requireOptional = (name, defaultValue) => {
+	try {
+		return require(name);
+	} catch (error) {
+		return defaultValue;
+	}
+};
 
-try {
-	Worker = require('worker_threads').Worker;
-} catch (error) {
-	Worker = undefined;
-}
+const {Worker} = requireOptional('worker_threads', {});
 
 let worker; // Lazy
 let taskIdCounter = 0;

--- a/index.js
+++ b/index.js
@@ -10,14 +10,14 @@ const taskWorker = (value, transferList) => new Promise(resolve => {
 	tasks.set(id, resolve);
 	if (worker === undefined) {
 		worker = new Worker('./thread.js');
-		worker.on('message', msg => {
-			const task = tasks.get(msg.id);
-			tasks.delete(msg.id);
+		worker.on('message', message => {
+			const task = tasks.get(message.id);
+			tasks.delete(message.id);
 			if (tasks.size === 0) {
 				worker.unref();
 			}
 
-			task(msg.value);
+			task(message.value);
 		});
 		worker.on('error', err => {
 			// Any error here is effectively an equivalent of segfault, and have no scope, so we just throw it on callback level

--- a/index.js
+++ b/index.js
@@ -5,24 +5,29 @@ let worker; // Lazy
 let taskIdCounter = 0;
 const tasks = new Map();
 
+const createWorker = () => {
+	worker = new Worker('./thread.js');
+	worker.on('message', message => {
+		const task = tasks.get(message.id);
+		tasks.delete(message.id);
+		if (tasks.size === 0) {
+			worker.unref();
+		}
+
+		task(message.value);
+	});
+	worker.on('error', err => {
+		// Any error here is effectively an equivalent of segfault and have no scope, so we just throw it on callback level
+		throw err;
+	});
+};
+
 const taskWorker = (value, transferList) => new Promise(resolve => {
 	const id = taskIdCounter++;
 	tasks.set(id, resolve);
-	if (worker === undefined) {
-		worker = new Worker('./thread.js');
-		worker.on('message', message => {
-			const task = tasks.get(message.id);
-			tasks.delete(message.id);
-			if (tasks.size === 0) {
-				worker.unref();
-			}
 
-			task(message.value);
-		});
-		worker.on('error', err => {
-			// Any error here is effectively an equivalent of segfault, and have no scope, so we just throw it on callback level
-			throw err;
-		});
+	if (worker === undefined) {
+		createWorker();
 	}
 
 	worker.postMessage({id, value}, transferList);

--- a/index.js
+++ b/index.js
@@ -61,28 +61,28 @@ let create = algorithm => async (buffer, options) => {
 };
 
 if (Worker !== undefined) {
-	create = algorithm => async (src, options) => {
+	create = algorithm => async (source, options) => {
 		options = {
 			outputFormat: 'hex',
 			...options
 		};
 
 		let buffer;
-		if (typeof src === 'string') {
+		if (typeof source === 'string') {
 			// Saving one copy operation by writing string to buffer right away and then transfering buffer
-			buffer = new ArrayBuffer(Buffer.byteLength(src, 'utf8'));
-			Buffer.from(buffer).write(src, 'utf8');
+			buffer = new ArrayBuffer(Buffer.byteLength(source, 'utf8'));
+			Buffer.from(buffer).write(source, 'utf8');
 		} else {
 			// Creating a copy of buffer at call time, will be transfered later
-			buffer = src.buffer.slice(0);
+			buffer = source.buffer.slice(0);
 		}
 
-		const res = await taskWorker({algorithm, buffer}, [buffer]);
+		const result = await taskWorker({algorithm, buffer}, [buffer]);
 		if (options.outputFormat === 'hex') {
-			return Buffer.from(res).toString('hex');
+			return Buffer.from(result).toString('hex');
 		}
 
-		return res;
+		return result;
 	};
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava test.js && karmatic test-browser.js && tsd"
@@ -18,7 +18,8 @@
 	"files": [
 		"index.js",
 		"index.d.ts",
-		"browser.js"
+		"browser.js",
+		"thread.js"
 	],
 	"keywords": [
 		"crypto",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
 		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	},
+	"eslintConfig": {
+		"rules": {
+			"import/no-unresolved": "ignore"
+		}
+	},
 	"browser": "browser.js"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava test.js && karmatic test-browser.js && tsd"

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
 		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	},
-	"eslintConfig": {
+	"browser": "browser.js",
+	"xo": {
 		"rules": {
-			"import/no-unresolved": "ignore"
+			"import/no-unresolved": "off"
 		}
-	},
-	"browser": "browser.js"
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ const {sha256} = require('crypto-hash');
 
 Returns a `Promise<string>` with a hex-encoded hash.
 
-*In Node.js operation is executed using [`worker_threads`](https://nodejs.org/api/worker_threads.html), one thread is lazily spawned on first operation and lives till the end of program execution(`unref`ed, so won't hold process alive).*
+*In Node.js 12 or later, the operation is executed using [`worker_threads`](https://nodejs.org/api/worker_threads.html). A thread is lazily spawned on the first operation and lives until the end of the program execution. It's `unref`ed, so it won't keep the process alive.*
 
 [SHA-1 is insecure](https://stackoverflow.com/a/38045085/64949) and should not be used for anything sensitive.
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ const {sha256} = require('crypto-hash');
 
 Returns a `Promise<string>` with a hex-encoded hash.
 
-*Note that even though it returns a promise, [in Node.js, the operation is synchronous 💩](https://github.com/nodejs/node/issues/678).*
+*In Node.js operation is executed using [`worker_threads`](https://nodejs.org/api/worker_threads.html), one thread is lazily spawned on first operation and lives till the end of program execution(`unref`ed, so won't hold process alive).*
 
 [SHA-1 is insecure](https://stackoverflow.com/a/38045085/64949) and should not be used for anything sensitive.
 

--- a/test.js
+++ b/test.js
@@ -34,3 +34,17 @@ test('buffer output', async t => {
 	const result = await sha1('🦄', {outputFormat: 'buffer'});
 	t.is(is(result), 'ArrayBuffer');
 });
+
+test('parallel execution', async t => {
+	const promises = [];
+	for (let i = 0; i < 10; i++) {
+		promises.push(sha512('🦄'));
+	}
+
+	const results = await Promise.all(promises);
+	t.is(results.length, promises.length);
+
+	for (const result of results) {
+		t.is(result, '7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905');
+	}
+});

--- a/thread.js
+++ b/thread.js
@@ -1,15 +1,7 @@
 'use strict';
+/* eslint-disable import/no-unresolved */
 const crypto = require('crypto');
-
-const requireOptional = (name, defaultValue) => {
-	try {
-		return require(name);
-	} catch (error) {
-		return defaultValue;
-	}
-};
-
-const {parentPort} = requireOptional('worker_threads', {});
+const {parentPort} = require('worker_threads');
 
 parentPort.on('message', message => {
 	const {algorithm, buffer} = message.value;

--- a/thread.js
+++ b/thread.js
@@ -1,6 +1,15 @@
 'use strict';
-const {parentPort} = require('worker_threads');
 const crypto = require('crypto');
+
+const requireOptional = (name, defaultValue) => {
+	try {
+		return require(name);
+	} catch (error) {
+		return defaultValue;
+	}
+};
+
+const {parentPort} = requireOptional('worker_threads', {});
 
 parentPort.on('message', message => {
 	const {algorithm, buffer} = message.value;

--- a/thread.js
+++ b/thread.js
@@ -1,6 +1,6 @@
 'use strict';
 const crypto = require('crypto');
-const {parentPort} = require('worker_threads'); // eslint-disable-line import/no-unresolved
+const {parentPort} = require('worker_threads'); // eslint-disable-line import/no-unresolved, eslint-comments/no-unused-disable
 
 parentPort.on('message', message => {
 	const {algorithm, buffer} = message.value;

--- a/thread.js
+++ b/thread.js
@@ -1,5 +1,4 @@
 'use strict';
-/* eslint-disable import/no-unresolved */
 const crypto = require('crypto');
 const {parentPort} = require('worker_threads');
 

--- a/thread.js
+++ b/thread.js
@@ -2,9 +2,11 @@
 const {parentPort} = require('worker_threads');
 const crypto = require('crypto');
 
-parentPort.on('message', (opts) => {
-	const hash = crypto.createHash(opts.algorithm);
-	hash.update(Buffer.from(opts.arrayBuf));
+parentPort.on('message', msg => {
+	const {algorithm, buffer} = msg.value;
+	const hash = crypto.createHash(algorithm);
+	hash.update(Buffer.from(buffer));
 	const arrayBuf = hash.digest().buffer;
-	parentPort.postMessage(arrayBuf, [arrayBuf]);
+	// Transfering buffer here for consistency, but considering buffer size it might be faster to just leave it for copying, needs perf test
+	parentPort.postMessage({id: msg.id, value: arrayBuf}, [arrayBuf]);
 });

--- a/thread.js
+++ b/thread.js
@@ -2,11 +2,11 @@
 const {parentPort} = require('worker_threads');
 const crypto = require('crypto');
 
-parentPort.on('message', msg => {
-	const {algorithm, buffer} = msg.value;
+parentPort.on('message', message => {
+	const {algorithm, buffer} = message.value;
 	const hash = crypto.createHash(algorithm);
 	hash.update(Buffer.from(buffer));
-	const arrayBuf = hash.digest().buffer;
+	const arrayBuffer = hash.digest().buffer;
 	// Transfering buffer here for consistency, but considering buffer size it might be faster to just leave it for copying, needs perf test
-	parentPort.postMessage({id: msg.id, value: arrayBuf}, [arrayBuf]);
+	parentPort.postMessage({id: message.id, value: arrayBuffer}, [arrayBuffer]);
 });

--- a/thread.js
+++ b/thread.js
@@ -1,15 +1,6 @@
 'use strict';
 const crypto = require('crypto');
-
-const requireOptional = (name, defaultValue) => {
-	try {
-		return require(name);
-	} catch (error) {
-		return defaultValue;
-	}
-};
-
-const {parentPort} = requireOptional('worker_threads', {});
+const {parentPort} = require('worker_threads');
 
 parentPort.on('message', message => {
 	const {algorithm, buffer} = message.value;
@@ -17,5 +8,8 @@ parentPort.on('message', message => {
 	hash.update(Buffer.from(buffer));
 	const arrayBuffer = hash.digest().buffer;
 	// Transfering buffer here for consistency, but considering buffer size it might be faster to just leave it for copying, needs perf test
+	parentPort.postMessage({id: message.id, value: arrayBuffer}, [arrayBuffer]);
+});
+ight be faster to just leave it for copying, needs perf test
 	parentPort.postMessage({id: message.id, value: arrayBuffer}, [arrayBuffer]);
 });

--- a/thread.js
+++ b/thread.js
@@ -1,6 +1,15 @@
 'use strict';
 const crypto = require('crypto');
-const {parentPort} = require('worker_threads'); // eslint-disable-line import/no-unresolved, eslint-comments/no-unused-disable
+
+const requireOptional = (name, defaultValue) => {
+	try {
+		return require(name);
+	} catch (error) {
+		return defaultValue;
+	}
+};
+
+const {parentPort} = requireOptional('worker_threads', {});
 
 parentPort.on('message', message => {
 	const {algorithm, buffer} = message.value;

--- a/thread.js
+++ b/thread.js
@@ -10,6 +10,3 @@ parentPort.on('message', message => {
 	// Transfering buffer here for consistency, but considering buffer size it might be faster to just leave it for copying, needs perf test
 	parentPort.postMessage({id: message.id, value: arrayBuffer}, [arrayBuffer]);
 });
-ight be faster to just leave it for copying, needs perf test
-	parentPort.postMessage({id: message.id, value: arrayBuffer}, [arrayBuffer]);
-});

--- a/thread.js
+++ b/thread.js
@@ -1,0 +1,10 @@
+'use strict';
+const {parentPort} = require('worker_threads');
+const crypto = require('crypto');
+
+parentPort.on('message', (opts) => {
+	const hash = crypto.createHash(opts.algorithm);
+	hash.update(Buffer.from(opts.arrayBuf));
+	const arrayBuf = hash.digest().buffer;
+	parentPort.postMessage(arrayBuf, [arrayBuf]);
+});

--- a/thread.js
+++ b/thread.js
@@ -1,6 +1,6 @@
 'use strict';
 const crypto = require('crypto');
-const {parentPort} = require('worker_threads');
+const {parentPort} = require('worker_threads'); // eslint-disable-line import/no-unresolved
 
 parentPort.on('message', message => {
 	const {algorithm, buffer} = message.value;


### PR DESCRIPTION
Fixes #6

Thread is lazily spawned.
Data is transferred without copying where possible.

For future improvement: benchmark it against small inputs(I'd start with smaller than 16KiB) and put a threshold on size below which hashing on the same thread is faster than sending it to another thread.
