### PR TITLE
Switch from spread operator to Object.assign

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -34,10 +34,7 @@ const create = algorithm => async (buffer, options) => {
 		buffer = new _globalThis.TextEncoder().encode(buffer);
 	}
 
-	options = {
-		outputFormat: 'hex',
-		...options
-	};
+	options = Object.assign({ outputFormat: 'hex' }, options);
 
 	const hash = await _globalThis.crypto.subtle.digest(algorithm, buffer);
 


### PR DESCRIPTION
Unfortunately the ...spread operation in object literals does not work in recent versions of Edge. Object.assign does though. Discovered this while trying to use this lib in an app on Edge.