### PR TITLE
Fix forgotten `ref()` for the worker

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ const taskWorker = (value, transferList) => new Promise(resolve => {
 		createWorker();
 	}
 
+	worker.ref();
 	worker.postMessage({id, value}, transferList);
 });
 


### PR DESCRIPTION
Accidentally deleted it at some stage. No idea how to write a test for this, as tests are `ref`ed themselves.