### PR TITLE
Fix importing the worker thread file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const crypto = require('crypto');
+const path = require('path');
 
 const requireOptional = (name, defaultValue) => {
 	try {
@@ -11,12 +12,14 @@ const requireOptional = (name, defaultValue) => {
 
 const {Worker} = requireOptional('worker_threads', {});
 
+const pathToThreadJs = path.join(__dirname, './thread.js');
+
 let worker; // Lazy
 let taskIdCounter = 0;
 const tasks = new Map();
 
 const createWorker = () => {
-	worker = new Worker('./thread.js');
+	worker = new Worker(pathToThreadJs);
 	worker.on('message', message => {
 		const task = tasks.get(message.id);
 		tasks.delete(message.id);

--- a/index.js
+++ b/index.js
@@ -12,14 +12,14 @@ const requireOptional = (name, defaultValue) => {
 
 const {Worker} = requireOptional('worker_threads', {});
 
-const pathToThreadJs = path.join(__dirname, './thread.js');
+const threadFilePath = path.join(__dirname, 'thread.js');
 
 let worker; // Lazy
 let taskIdCounter = 0;
 const tasks = new Map();
 
 const createWorker = () => {
-	worker = new Worker(pathToThreadJs);
+	worker = new Worker(threadFilePath);
 	worker.on('message', message => {
 		const task = tasks.get(message.id);
 		tasks.delete(message.id);


### PR DESCRIPTION
Before it would fail if you use `crypto-hash` with Node `12` (or anything with `worker_threads` rather). The tests didn't fail because they run with `$PWD` pointing to the repo.

```js
const {sha512} = require('crypto-hash')
sha512('foo').then(console.log, console.error)
```

```
[Error: Cannot find module '/Users/j/playground/thread.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:623:15)
    at Function.Module._load (internal/modules/cjs/loader.js:527:27)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at MessagePort.<anonymous> (internal/main/worker_thread.js:139:25)
    at MessagePort.emit (events.js:200:13)
    at MessagePort.onmessage (internal/worker/io.js:70:8) {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}] {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

One way to test this might be to move `test.js` to `test/index.js` and then run `cd test; ava index.js`.