### PR TITLE
WIP hmac support

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -23,7 +23,10 @@ const bufferToHex = buffer => {
 
 	let hexCodes = '';
 	for (let i = 0; i < view.byteLength; i += 4) {
-		hexCodes += view.getUint32(i).toString(16).padStart(8, '0');
+		hexCodes += view
+			.getUint32(i)
+			.toString(16)
+			.padStart(8, '0');
 	}
 
 	return hexCodes;
@@ -43,6 +46,27 @@ const create = algorithm => async (buffer, options) => {
 
 	return options.outputFormat === 'hex' ? bufferToHex(hash) : hash;
 };
+
+// Async function hmac(key, string, encoding) {
+// 	const cryptoKey = await crypto.subtle.importKey(
+// 		'raw',
+// 		typeof key === 'string' ? encoder.encode(key) : key,
+// 		{name: 'HMAC', hash: {name: 'SHA-256'}},
+// 		false,
+// 		['sign']
+// 	);
+// 	const signed = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(string));
+// 	return encoding === 'hex' ? buf2hex(signed) : signed;
+// }
+
+// async function hash(content, encoding) {
+// 	const digest = await crypto.subtle.digest('SHA-256', typeof content === 'string' ? encoder.encode(content) : content);
+// 	return encoding === 'hex' ? buf2hex(digest) : digest;
+// }
+
+// function buf2hex(buffer) {
+// 	return Array.prototype.map.call(new Uint8Array(buffer), x => ('0' + x.toString(16)).slice(-2)).join('');
+// }
 
 exports.sha1 = create('SHA-1');
 exports.sha256 = create('SHA-256');

--- a/index.js
+++ b/index.js
@@ -1,96 +1,138 @@
-'use strict';
-const crypto = require('crypto');
-const path = require('path');
+'use strict'
+const crypto = require('crypto')
+const path = require('path')
 
 const requireOptional = (name, defaultValue) => {
 	try {
-		return require(name);
+		return require(name)
 	} catch (_) {
-		return defaultValue;
+		return defaultValue
 	}
-};
+}
 
-const {Worker} = requireOptional('worker_threads', {});
+const { Worker } = requireOptional('worker_threads', {})
 
-const threadFilePath = path.join(__dirname, 'thread.js');
+const threadFilePath = path.join(__dirname, 'thread.js')
 
-let worker; // Lazy
-let taskIdCounter = 0;
-const tasks = new Map();
+let worker // Lazy
+let taskIdCounter = 0
+const tasks = new Map()
 
 const createWorker = () => {
-	worker = new Worker(threadFilePath);
+	worker = new Worker(threadFilePath)
 	worker.on('message', message => {
-		const task = tasks.get(message.id);
-		tasks.delete(message.id);
+		const task = tasks.get(message.id)
+		tasks.delete(message.id)
 		if (tasks.size === 0) {
-			worker.unref();
+			worker.unref()
 		}
 
-		task(message.value);
-	});
+		task(message.value)
+	})
 
 	worker.on('error', error => {
 		// Any error here is effectively an equivalent of segfault and have no scope, so we just throw it on callback level
-		throw error;
-	});
-};
+		throw error
+	})
+}
 
-const taskWorker = (value, transferList) => new Promise(resolve => {
-	const id = taskIdCounter++;
-	tasks.set(id, resolve);
+const taskWorker = (value, transferList) =>
+	new Promise(resolve => {
+		const id = taskIdCounter++
+		tasks.set(id, resolve)
 
-	if (worker === undefined) {
-		createWorker();
-	}
+		if (worker === undefined) {
+			createWorker()
+		}
 
-	worker.ref();
-	worker.postMessage({id, value}, transferList);
-});
+		worker.ref()
+		worker.postMessage({ id, value }, transferList)
+	})
 
 let create = algorithm => async (buffer, options) => {
 	options = {
 		outputFormat: 'hex',
 		...options
-	};
-
-	const hash = crypto.createHash(algorithm);
-	hash.update(buffer, typeof buffer === 'string' ? 'utf8' : undefined);
-
-	if (options.outputFormat === 'hex') {
-		return hash.digest('hex');
 	}
 
-	return hash.digest().buffer;
-};
+	const hash = crypto.createHash(algorithm)
+	hash.update(buffer, typeof buffer === 'string' ? 'utf8' : undefined)
+
+	if (options.outputFormat === 'hex') {
+		return hash.digest('hex')
+	}
+
+	return hash.digest().buffer
+}
+
+const hmac = algorithm => async (key, buffer, options) => {
+	options = {
+		outputFormat: 'hex',
+		...options
+	}
+
+	const hash = crypto.createHmac(algorithm, key)
+	hash.update(buffer)
+
+	if (options.outputFormat === 'hex') {
+		return hash.digest('hex')
+	}
+
+	if (options.outputFormat === 'base64') {
+		return hash.digest('base64')
+	}
+
+	return hash.digest().buffer
+}
 
 if (Worker !== undefined) {
 	create = algorithm => async (source, options) => {
 		options = {
 			outputFormat: 'hex',
 			...options
-		};
+		}
 
-		let buffer;
+		let buffer
 		if (typeof source === 'string') {
 			// Saving one copy operation by writing string to buffer right away and then transfering buffer
-			buffer = new ArrayBuffer(Buffer.byteLength(source, 'utf8'));
-			Buffer.from(buffer).write(source, 'utf8');
+			buffer = new ArrayBuffer(Buffer.byteLength(source, 'utf8'))
+			Buffer.from(buffer).write(source, 'utf8')
 		} else {
 			// Creating a copy of buffer at call time, will be transfered later
-			buffer = source.buffer.slice(0);
+			buffer = source.buffer.slice(0)
 		}
 
-		const result = await taskWorker({algorithm, buffer}, [buffer]);
+		const result = await taskWorker({ algorithm, buffer }, [buffer])
 		if (options.outputFormat === 'hex') {
-			return Buffer.from(result).toString('hex');
+			return Buffer.from(result).toString('hex')
 		}
 
-		return result;
-	};
+		return result
+	}
+
+	// Hmac = algorithm => async (key, buffer, options) => {
+	// 	options = {
+	// 		outputFormat: 'hex',
+	// 		...options
+	// 	}
+
+	// 	const hash = crypto.createHmac(algorithm, key)
+	// 	hash.update(buffer, typeof buffer === 'string' ? 'utf8' : undefined)
+
+	// 	if (options.outputFormat === 'hex') {
+	// 		return hash.digest('hex')
+	// 	}
+
+	// 	return hash.digest().buffer
+	// }
 }
 
-exports.sha1 = create('sha1');
-exports.sha256 = create('sha256');
-exports.sha384 = create('sha384');
-exports.sha512 = create('sha512');
+exports.sha1 = create('sha1')
+exports.sha256 = create('sha256')
+exports.sha384 = create('sha384')
+exports.sha512 = create('sha512')
+exports.hmac = {}
+exports.hmac.sha1 = hmac('sha1')
+exports.hmac.sha256 = hmac('sha256')
+exports.hmac.sha384 = hmac('sha384')
+exports.hmac.sha512 = hmac('sha512')

--- a/index.js
+++ b/index.js
@@ -1,114 +1,114 @@
-'use strict'
-const crypto = require('crypto')
-const path = require('path')
+'use strict';
+const crypto = require('crypto');
+const path = require('path');
 
 const requireOptional = (name, defaultValue) => {
 	try {
-		return require(name)
+		return require(name);
 	} catch (_) {
-		return defaultValue
+		return defaultValue;
 	}
-}
+};
 
-const { Worker } = requireOptional('worker_threads', {})
+const {Worker} = requireOptional('worker_threads', {});
 
-const threadFilePath = path.join(__dirname, 'thread.js')
+const threadFilePath = path.join(__dirname, 'thread.js');
 
-let worker // Lazy
-let taskIdCounter = 0
-const tasks = new Map()
+let worker; // Lazy
+let taskIdCounter = 0;
+const tasks = new Map();
 
 const createWorker = () => {
-	worker = new Worker(threadFilePath)
+	worker = new Worker(threadFilePath);
 	worker.on('message', message => {
-		const task = tasks.get(message.id)
-		tasks.delete(message.id)
+		const task = tasks.get(message.id);
+		tasks.delete(message.id);
 		if (tasks.size === 0) {
-			worker.unref()
+			worker.unref();
 		}
 
-		task(message.value)
-	})
+		task(message.value);
+	});
 
 	worker.on('error', error => {
 		// Any error here is effectively an equivalent of segfault and have no scope, so we just throw it on callback level
-		throw error
-	})
-}
+		throw error;
+	});
+};
 
 const taskWorker = (value, transferList) =>
 	new Promise(resolve => {
-		const id = taskIdCounter++
-		tasks.set(id, resolve)
+		const id = taskIdCounter++;
+		tasks.set(id, resolve);
 
 		if (worker === undefined) {
-			createWorker()
+			createWorker();
 		}
 
-		worker.ref()
-		worker.postMessage({ id, value }, transferList)
-	})
+		worker.ref();
+		worker.postMessage({id, value}, transferList);
+	});
 
 let create = algorithm => async (buffer, options) => {
 	options = {
 		outputFormat: 'hex',
 		...options
-	}
+	};
 
-	const hash = crypto.createHash(algorithm)
-	hash.update(buffer, typeof buffer === 'string' ? 'utf8' : undefined)
+	const hash = crypto.createHash(algorithm);
+	hash.update(buffer, typeof buffer === 'string' ? 'utf8' : undefined);
 
 	if (options.outputFormat === 'hex') {
-		return hash.digest('hex')
+		return hash.digest('hex');
 	}
 
-	return hash.digest().buffer
-}
+	return hash.digest().buffer;
+};
 
 const hmac = algorithm => async (key, buffer, options) => {
 	options = {
 		outputFormat: 'hex',
 		...options
-	}
+	};
 
-	const hash = crypto.createHmac(algorithm, key)
-	hash.update(buffer)
+	const hash = crypto.createHmac(algorithm, key);
+	hash.update(buffer);
 
 	if (options.outputFormat === 'hex') {
-		return hash.digest('hex')
+		return hash.digest('hex');
 	}
 
 	if (options.outputFormat === 'base64') {
-		return hash.digest('base64')
+		return hash.digest('base64');
 	}
 
-	return hash.digest().buffer
-}
+	return hash.digest().buffer;
+};
 
 if (Worker !== undefined) {
 	create = algorithm => async (source, options) => {
 		options = {
 			outputFormat: 'hex',
 			...options
-		}
+		};
 
-		let buffer
+		let buffer;
 		if (typeof source === 'string') {
 			// Saving one copy operation by writing string to buffer right away and then transfering buffer
-			buffer = new ArrayBuffer(Buffer.byteLength(source, 'utf8'))
-			Buffer.from(buffer).write(source, 'utf8')
+			buffer = new ArrayBuffer(Buffer.byteLength(source, 'utf8'));
+			Buffer.from(buffer).write(source, 'utf8');
 		} else {
 			// Creating a copy of buffer at call time, will be transfered later
-			buffer = source.buffer.slice(0)
+			buffer = source.buffer.slice(0);
 		}
 
-		const result = await taskWorker({ algorithm, buffer }, [buffer])
+		const result = await taskWorker({algorithm, buffer}, [buffer]);
 		if (options.outputFormat === 'hex') {
-			return Buffer.from(result).toString('hex')
+			return Buffer.from(result).toString('hex');
 		}
 
-		return result
-	}
+		return result;
+	};
 
 	// Hmac = algorithm => async (key, buffer, options) => {
 	// 	options = {
@@ -127,12 +127,12 @@ if (Worker !== undefined) {
 	// }
 }
 
-exports.sha1 = create('sha1')
-exports.sha256 = create('sha256')
-exports.sha384 = create('sha384')
-exports.sha512 = create('sha512')
-exports.hmac = {}
-exports.hmac.sha1 = hmac('sha1')
-exports.hmac.sha256 = hmac('sha256')
-exports.hmac.sha384 = hmac('sha384')
-exports.hmac.sha512 = hmac('sha512')
+exports.sha1 = create('sha1');
+exports.sha256 = create('sha256');
+exports.sha384 = create('sha384');
+exports.sha512 = create('sha512');
+exports.hmac = {};
+exports.hmac.sha1 = hmac('sha1');
+exports.hmac.sha256 = hmac('sha256');
+exports.hmac.sha384 = hmac('sha384');
+exports.hmac.sha512 = hmac('sha512');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	"devDependencies": {
 		"@sindresorhus/is": "^0.15.0",
 		"ava": "^1.4.1",
+		"crypto-js": "3.1.9-1",
 		"hash.js": "^1.1.5",
 		"karmatic": "1.0.7",
 		"tsd": "^0.7.2",

--- a/test-browser.js
+++ b/test-browser.js
@@ -1,38 +1,113 @@
 /* eslint-env jasmine */
-'use strict';
-const hashjs = require('hash.js');
-const is = require('@sindresorhus/is');
-const {sha1, sha256, sha384, sha512} = require('./browser');
+'use strict'
+const hashjs = require('hash.js')
+const is = require('@sindresorhus/is')
+const { sha1, sha256, sha384, sha512, hmac } = require('./browser')
 
-const fixture = 'foo bar baz';
+const fixture = 'foo bar baz'
 
 it('sha1', async () => {
-	expect(await sha1('🦄')).toEqual('5df82936cbf0864be4b7ba801bee392457fde9e4');
-	expect(await sha1(fixture)).toEqual(hashjs.sha1().update(fixture).digest('hex'));
-});
+	expect(await sha1('🦄')).toEqual('5df82936cbf0864be4b7ba801bee392457fde9e4')
+	expect(await sha1(fixture)).toEqual(
+		hashjs
+			.sha1()
+			.update(fixture)
+			.digest('hex')
+	)
+})
 
 it('sha256', async () => {
-	expect(await sha256('🦄')).toEqual('36bf255468003165652fe978eaaa8898e191664028475f83f506dabd95298efc');
-	expect(await sha256(fixture)).toEqual(hashjs.sha256().update(fixture).digest('hex'));
-});
+	expect(await sha256('🦄')).toEqual(
+		'36bf255468003165652fe978eaaa8898e191664028475f83f506dabd95298efc'
+	)
+	expect(await sha256(fixture)).toEqual(
+		hashjs
+			.sha256()
+			.update(fixture)
+			.digest('hex')
+	)
+})
 
 it('sha384', async () => {
-	expect(await sha384('🦄')).toEqual('a9d4dfb503394bd9701d60eb5fb1d7fb800580b43d874165103b16d311fb5c97545cb89f06c31f30e219f5b603e834ca');
-	expect(await sha384(fixture)).toEqual(hashjs.sha384().update(fixture).digest('hex'));
-});
+	expect(await sha384('🦄')).toEqual(
+		'a9d4dfb503394bd9701d60eb5fb1d7fb800580b43d874165103b16d311fb5c97545cb89f06c31f30e219f5b603e834ca'
+	)
+	expect(await sha384(fixture)).toEqual(
+		hashjs
+			.sha384()
+			.update(fixture)
+			.digest('hex')
+	)
+})
 
 it('sha512', async () => {
-	expect(await sha512('🦄')).toEqual('7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905');
-	expect(await sha512(fixture)).toEqual(hashjs.sha512().update(fixture).digest('hex'));
-});
+	expect(await sha512('🦄')).toEqual(
+		'7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905'
+	)
+	expect(await sha512(fixture)).toEqual(
+		hashjs
+			.sha512()
+			.update(fixture)
+			.digest('hex')
+	)
+})
+
+it('hmac.sha1', async () => {
+	expect(await hmac.sha1('🦄')).toEqual(
+		'5df82936cbf0864be4b7ba801bee392457fde9e4'
+	)
+	expect(await hmac.sha1(fixture)).toEqual(
+		hashjs
+			.sha1()
+			.update(fixture)
+			.digest('hex')
+	)
+})
+
+it('hmac.sha256', async () => {
+	expect(await hmac.sha256('🦄')).toEqual(
+		'36bf255468003165652fe978eaaa8898e191664028475f83f506dabd95298efc'
+	)
+	expect(await hmac.sha256(fixture)).toEqual(
+		hashjs
+			.sha256()
+			.update(fixture)
+			.digest('hex')
+	)
+})
+
+it('hmac.sha384', async () => {
+	expect(await sha384('🦄')).toEqual(
+		'a9d4dfb503394bd9701d60eb5fb1d7fb800580b43d874165103b16d311fb5c97545cb89f06c31f30e219f5b603e834ca'
+	)
+	expect(await hmac.sha384(fixture)).toEqual(
+		hashjs
+			.sha384()
+			.update(fixture)
+			.digest('hex')
+	)
+})
+
+it('hmac.sha512', async () => {
+	expect(await hmac.sha512('🦄')).toEqual(
+		'7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905'
+	)
+	expect(await hmac.sha512(fixture)).toEqual(
+		hashjs
+			.sha512()
+			.update(fixture)
+			.digest('hex')
+	)
+})
 
 it('buffer input', async () => {
-	const fixture = new Uint16Array([1, 2, 3]);
-	expect(await sha1(fixture)).toEqual('5b9ba303e3d8ef9e9d421085303cda49d64c79bf');
-});
+	const fixture = new Uint16Array([1, 2, 3])
+	expect(await sha1(fixture)).toEqual(
+		'5b9ba303e3d8ef9e9d421085303cda49d64c79bf'
+	)
+})
 
 it('buffer output', async () => {
-	const result = await sha1('🦄', {outputFormat: 'buffer'});
-	expect(is(result)).toEqual('ArrayBuffer');
-});
-
+	const result = await sha1('🦄', { outputFormat: 'buffer' })
+	expect(is(result)).toEqual('ArrayBuffer')
+})

--- a/test-browser.js
+++ b/test-browser.js
@@ -1,113 +1,113 @@
 /* eslint-env jasmine */
-'use strict'
-const hashjs = require('hash.js')
-const is = require('@sindresorhus/is')
-const { sha1, sha256, sha384, sha512, hmac } = require('./browser')
+'use strict';
+const hashjs = require('hash.js');
+const is = require('@sindresorhus/is');
+const {sha1, sha256, sha384, sha512, hmac} = require('./browser');
 
-const fixture = 'foo bar baz'
+const fixture = 'foo bar baz';
 
 it('sha1', async () => {
-	expect(await sha1('🦄')).toEqual('5df82936cbf0864be4b7ba801bee392457fde9e4')
+	expect(await sha1('🦄')).toEqual('5df82936cbf0864be4b7ba801bee392457fde9e4');
 	expect(await sha1(fixture)).toEqual(
 		hashjs
 			.sha1()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 it('sha256', async () => {
 	expect(await sha256('🦄')).toEqual(
 		'36bf255468003165652fe978eaaa8898e191664028475f83f506dabd95298efc'
-	)
+	);
 	expect(await sha256(fixture)).toEqual(
 		hashjs
 			.sha256()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 it('sha384', async () => {
 	expect(await sha384('🦄')).toEqual(
 		'a9d4dfb503394bd9701d60eb5fb1d7fb800580b43d874165103b16d311fb5c97545cb89f06c31f30e219f5b603e834ca'
-	)
+	);
 	expect(await sha384(fixture)).toEqual(
 		hashjs
 			.sha384()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 it('sha512', async () => {
 	expect(await sha512('🦄')).toEqual(
 		'7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905'
-	)
+	);
 	expect(await sha512(fixture)).toEqual(
 		hashjs
 			.sha512()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 it('hmac.sha1', async () => {
 	expect(await hmac.sha1('🦄')).toEqual(
 		'5df82936cbf0864be4b7ba801bee392457fde9e4'
-	)
+	);
 	expect(await hmac.sha1(fixture)).toEqual(
 		hashjs
 			.sha1()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 it('hmac.sha256', async () => {
 	expect(await hmac.sha256('🦄')).toEqual(
 		'36bf255468003165652fe978eaaa8898e191664028475f83f506dabd95298efc'
-	)
+	);
 	expect(await hmac.sha256(fixture)).toEqual(
 		hashjs
 			.sha256()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 it('hmac.sha384', async () => {
 	expect(await sha384('🦄')).toEqual(
 		'a9d4dfb503394bd9701d60eb5fb1d7fb800580b43d874165103b16d311fb5c97545cb89f06c31f30e219f5b603e834ca'
-	)
+	);
 	expect(await hmac.sha384(fixture)).toEqual(
 		hashjs
 			.sha384()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 it('hmac.sha512', async () => {
 	expect(await hmac.sha512('🦄')).toEqual(
 		'7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905'
-	)
+	);
 	expect(await hmac.sha512(fixture)).toEqual(
 		hashjs
 			.sha512()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 it('buffer input', async () => {
-	const fixture = new Uint16Array([1, 2, 3])
+	const fixture = new Uint16Array([1, 2, 3]);
 	expect(await sha1(fixture)).toEqual(
 		'5b9ba303e3d8ef9e9d421085303cda49d64c79bf'
-	)
-})
+	);
+});
 
 it('buffer output', async () => {
-	const result = await sha1('🦄', { outputFormat: 'buffer' })
-	expect(is(result)).toEqual('ArrayBuffer')
-})
+	const result = await sha1('🦄', {outputFormat: 'buffer'});
+	expect(is(result)).toEqual('ArrayBuffer');
+});

--- a/test.js
+++ b/test.js
@@ -1,50 +1,145 @@
-import test from 'ava';
-import hashjs from 'hash.js';
-import is from '@sindresorhus/is';
-import {sha1, sha256, sha384, sha512} from '.';
+import test from 'ava'
+import hashjs from 'hash.js'
+import cryptojs from 'crypto-js'
+import is from '@sindresorhus/is'
+import { sha1, sha256, sha384, sha512, hmac } from '.'
 
-const fixture = 'foo bar baz';
+const fixture = 'foo bar baz'
+const fixtureKey = 'secret fixture key'
 
 test('sha1', async t => {
-	t.is(await sha1('🦄'), '5df82936cbf0864be4b7ba801bee392457fde9e4');
-	t.is(await sha1(fixture), hashjs.sha1().update(fixture).digest('hex'));
-});
+	t.is(await sha1('🦄'), '5df82936cbf0864be4b7ba801bee392457fde9e4')
+	t.is(
+		await sha1(fixture),
+		hashjs
+			.sha1()
+			.update(fixture)
+			.digest('hex')
+	)
+})
 
 test('sha256', async t => {
-	t.is(await sha256('🦄'), '36bf255468003165652fe978eaaa8898e191664028475f83f506dabd95298efc');
-	t.is(await sha256(fixture), hashjs.sha256().update(fixture).digest('hex'));
-});
+	t.is(
+		await sha256('🦄'),
+		'36bf255468003165652fe978eaaa8898e191664028475f83f506dabd95298efc'
+	)
+	t.is(
+		await sha256(fixture),
+		hashjs
+			.sha256()
+			.update(fixture)
+			.digest('hex')
+	)
+})
 
 test('sha384', async t => {
-	t.is(await sha384('🦄'), 'a9d4dfb503394bd9701d60eb5fb1d7fb800580b43d874165103b16d311fb5c97545cb89f06c31f30e219f5b603e834ca');
-	t.is(await sha384(fixture), hashjs.sha384().update(fixture).digest('hex'));
-});
+	t.is(
+		await sha384('🦄'),
+		'a9d4dfb503394bd9701d60eb5fb1d7fb800580b43d874165103b16d311fb5c97545cb89f06c31f30e219f5b603e834ca'
+	)
+	t.is(
+		await sha384(fixture),
+		hashjs
+			.sha384()
+			.update(fixture)
+			.digest('hex')
+	)
+})
 
 test('sha512', async t => {
-	t.is(await sha512('🦄'), '7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905');
-	t.is(await sha512(fixture), hashjs.sha512().update(fixture).digest('hex'));
-});
+	t.is(
+		await sha512('🦄'),
+		'7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905'
+	)
+	t.is(
+		await sha512(fixture),
+		hashjs
+			.sha512()
+			.update(fixture)
+			.digest('hex')
+	)
+})
+
+test('hmac - sha1', async t => {
+	t.is(
+		await hmac.sha1('secret key foo', '🦄'),
+		'355ecf1f695dfc969b5d0db9dba08105f99943a0'
+	)
+	t.is(
+		await hmac.sha1(fixtureKey, fixture),
+		cryptojs.HmacSHA1(fixture, fixtureKey).toString(cryptojs.enc.Hex)
+	)
+})
+
+test('hmac - sha256', async t => {
+	t.is(
+		await hmac.sha256('secret key foo', '🦄'),
+		'09a764f7324829c8c54a82d84d2e33049e09ed3f28929a1d08835346be324471'
+	)
+	t.is(
+		await hmac.sha256(fixtureKey, fixture),
+		cryptojs.HmacSHA256(fixture, fixtureKey).toString(cryptojs.enc.Hex)
+	)
+})
+
+test('hmac - sha384', async t => {
+	t.is(
+		await hmac.sha384('secret key foo', '🦄'),
+		'36bc8cccea6c3ff35c9f761672c7c4227dafdece4e0401f530dfd12e4c4541e7506e84cd4bb745d7fb61be4c28ba1a38'
+	)
+	t.is(
+		await hmac.sha384(fixtureKey, fixture),
+		cryptojs.HmacSHA384(fixture, fixtureKey).toString(cryptojs.enc.Hex)
+	)
+})
+
+test('hmac - sha512', async t => {
+	t.is(
+		await sha512('secret key foo', '🦄'),
+		'15d88d583f896083c72cce95bd9c7ae7489693858b06e5a98935c654c80000529f1ac4a05347bdb9222535e24044b1f4a3d256bfccc9d45e28c54aa3ff81e185'
+	)
+	t.is(
+		await hmac.sha512(fixtureKey, fixture),
+		cryptojs.HmacSHA512(fixture, fixtureKey).toString(cryptojs.enc.Hex)
+	)
+})
 
 test('buffer input', async t => {
-	const fixture = new Uint16Array([1, 2, 3]);
-	t.is(await sha1(fixture), '5b9ba303e3d8ef9e9d421085303cda49d64c79bf');
-});
+	const fixture = new Uint16Array([1, 2, 3])
+	t.is(await sha1(fixture), '5b9ba303e3d8ef9e9d421085303cda49d64c79bf')
+})
+
+test('hmac - buffer input', async t => {
+	const fixture = new Uint16Array([1, 2, 3])
+	t.is(
+		await hmac.sha1(fixtureKey, fixture),
+		'287d1c7842239843c170558dd3dfe0d7ca53bfb6'
+	)
+})
 
 test('buffer output', async t => {
-	const result = await sha1('🦄', {outputFormat: 'buffer'});
-	t.is(is(result), 'ArrayBuffer');
-});
+	const result = await sha1('🦄', { outputFormat: 'buffer' })
+	t.is(is(result), 'ArrayBuffer')
+})
+
+test('hmac - buffer output', async t => {
+	const result = await sha1('🦄', { outputFormat: 'buffer' })
+	t.is(is(result), 'ArrayBuffer')
+})
 
 test('parallel execution', async t => {
-	const promises = [];
+	const promises = []
 	for (let i = 0; i < 10; i++) {
-		promises.push(sha512('🦄'));
+		promises.push(sha512('🦄'))
 	}
 
-	const results = await Promise.all(promises);
-	t.is(results.length, promises.length);
+	const results = await Promise.all(promises)
+	t.is(results.length, promises.length)
 
 	for (const result of results) {
-		t.is(result, '7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905');
+		t.is(
+			result,
+			'7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905'
+		)
 	}
-});
+})

--- a/test.js
+++ b/test.js
@@ -1,145 +1,145 @@
-import test from 'ava'
-import hashjs from 'hash.js'
-import cryptojs from 'crypto-js'
-import is from '@sindresorhus/is'
-import { sha1, sha256, sha384, sha512, hmac } from '.'
+import test from 'ava';
+import hashjs from 'hash.js';
+import cryptojs from 'crypto-js';
+import is from '@sindresorhus/is';
+import {sha1, sha256, sha384, sha512, hmac} from '.';
 
-const fixture = 'foo bar baz'
-const fixtureKey = 'secret fixture key'
+const fixture = 'foo bar baz';
+const fixtureKey = 'secret fixture key';
 
 test('sha1', async t => {
-	t.is(await sha1('🦄'), '5df82936cbf0864be4b7ba801bee392457fde9e4')
+	t.is(await sha1('🦄'), '5df82936cbf0864be4b7ba801bee392457fde9e4');
 	t.is(
 		await sha1(fixture),
 		hashjs
 			.sha1()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 test('sha256', async t => {
 	t.is(
 		await sha256('🦄'),
 		'36bf255468003165652fe978eaaa8898e191664028475f83f506dabd95298efc'
-	)
+	);
 	t.is(
 		await sha256(fixture),
 		hashjs
 			.sha256()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 test('sha384', async t => {
 	t.is(
 		await sha384('🦄'),
 		'a9d4dfb503394bd9701d60eb5fb1d7fb800580b43d874165103b16d311fb5c97545cb89f06c31f30e219f5b603e834ca'
-	)
+	);
 	t.is(
 		await sha384(fixture),
 		hashjs
 			.sha384()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 test('sha512', async t => {
 	t.is(
 		await sha512('🦄'),
 		'7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905'
-	)
+	);
 	t.is(
 		await sha512(fixture),
 		hashjs
 			.sha512()
 			.update(fixture)
 			.digest('hex')
-	)
-})
+	);
+});
 
 test('hmac - sha1', async t => {
 	t.is(
 		await hmac.sha1('secret key foo', '🦄'),
 		'355ecf1f695dfc969b5d0db9dba08105f99943a0'
-	)
+	);
 	t.is(
 		await hmac.sha1(fixtureKey, fixture),
 		cryptojs.HmacSHA1(fixture, fixtureKey).toString(cryptojs.enc.Hex)
-	)
-})
+	);
+});
 
 test('hmac - sha256', async t => {
 	t.is(
 		await hmac.sha256('secret key foo', '🦄'),
 		'09a764f7324829c8c54a82d84d2e33049e09ed3f28929a1d08835346be324471'
-	)
+	);
 	t.is(
 		await hmac.sha256(fixtureKey, fixture),
 		cryptojs.HmacSHA256(fixture, fixtureKey).toString(cryptojs.enc.Hex)
-	)
-})
+	);
+});
 
 test('hmac - sha384', async t => {
 	t.is(
 		await hmac.sha384('secret key foo', '🦄'),
 		'36bc8cccea6c3ff35c9f761672c7c4227dafdece4e0401f530dfd12e4c4541e7506e84cd4bb745d7fb61be4c28ba1a38'
-	)
+	);
 	t.is(
 		await hmac.sha384(fixtureKey, fixture),
 		cryptojs.HmacSHA384(fixture, fixtureKey).toString(cryptojs.enc.Hex)
-	)
-})
+	);
+});
 
 test('hmac - sha512', async t => {
 	t.is(
 		await sha512('secret key foo', '🦄'),
 		'15d88d583f896083c72cce95bd9c7ae7489693858b06e5a98935c654c80000529f1ac4a05347bdb9222535e24044b1f4a3d256bfccc9d45e28c54aa3ff81e185'
-	)
+	);
 	t.is(
 		await hmac.sha512(fixtureKey, fixture),
 		cryptojs.HmacSHA512(fixture, fixtureKey).toString(cryptojs.enc.Hex)
-	)
-})
+	);
+});
 
 test('buffer input', async t => {
-	const fixture = new Uint16Array([1, 2, 3])
-	t.is(await sha1(fixture), '5b9ba303e3d8ef9e9d421085303cda49d64c79bf')
-})
+	const fixture = new Uint16Array([1, 2, 3]);
+	t.is(await sha1(fixture), '5b9ba303e3d8ef9e9d421085303cda49d64c79bf');
+});
 
 test('hmac - buffer input', async t => {
-	const fixture = new Uint16Array([1, 2, 3])
+	const fixture = new Uint16Array([1, 2, 3]);
 	t.is(
 		await hmac.sha1(fixtureKey, fixture),
 		'287d1c7842239843c170558dd3dfe0d7ca53bfb6'
-	)
-})
+	);
+});
 
 test('buffer output', async t => {
-	const result = await sha1('🦄', { outputFormat: 'buffer' })
-	t.is(is(result), 'ArrayBuffer')
-})
+	const result = await sha1('🦄', {outputFormat: 'buffer'});
+	t.is(is(result), 'ArrayBuffer');
+});
 
 test('hmac - buffer output', async t => {
-	const result = await sha1('🦄', { outputFormat: 'buffer' })
-	t.is(is(result), 'ArrayBuffer')
-})
+	const result = await sha1('🦄', {outputFormat: 'buffer'});
+	t.is(is(result), 'ArrayBuffer');
+});
 
 test('parallel execution', async t => {
-	const promises = []
+	const promises = [];
 	for (let i = 0; i < 10; i++) {
-		promises.push(sha512('🦄'))
+		promises.push(sha512('🦄'));
 	}
 
-	const results = await Promise.all(promises)
-	t.is(results.length, promises.length)
+	const results = await Promise.all(promises);
+	t.is(results.length, promises.length);
 
 	for (const result of results) {
 		t.is(
 			result,
 			'7d9e515c59bd15d0692f9bc0c68f50f82b62a99bef4b8dc490cec165296210dff005529a4cb84a655eee6ddec82339e6bdbab21bdb287b71a543a56cfab53905'
-		)
+		);
 	}
-})
+});


### PR DESCRIPTION
This still needs work but wanted to open for any feedback on the API:

``` js
import { hmac } from "crypto-hash"

hmac.sha256("my secret key", "text to sign")
hmac.sha256("my secret key", "text to sign", { output: "buffer" })
hmac.sha256("my secret key", "text to sign", { output: "base64" })
```

Not sure if the `hmac` container object makes sense. Could also put them the top-level: 

`import { hmacSha256 } from "crypto-hash" `