### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"index.js",
 		"index.d.ts",
 		"browser.js",
-		"brower.d.ts",
+		"browser.d.ts",
 		"thread.js"
 	],
 	"keywords": [


### PR DESCRIPTION
Hi! I noticed there's a typo in the files array; There's no `brower.d.ts` file so these type definitions were not probably sent out. Hope this helps!