### PR TITLE
 Goodbye node.js Buffer

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -16,6 +16,7 @@ const create = algorithm => async (buffer, {outputFormat = 'hex'} = {}) => {
 		buffer = new globalThis.TextEncoder().encode(buffer);
 	}
 
+	// eslint-disable-next-line n/no-unsupported-features/node-builtins
 	const hash = await globalThis.crypto.subtle.digest(algorithm, buffer);
 
 	return outputFormat === 'hex' ? bufferToHex(hash) : hash;

--- a/browser.js
+++ b/browser.js
@@ -1,22 +1,10 @@
-/* eslint-env browser */
-
-const bufferToHex = buffer => {
-	const view = new DataView(buffer);
-
-	let hexCodes = '';
-	for (let index = 0; index < view.byteLength; index += 4) {
-		hexCodes += view.getUint32(index).toString(16).padStart(8, '0');
-	}
-
-	return hexCodes;
-};
+import {bufferToHex} from './utilities.js';
 
 const create = algorithm => async (buffer, {outputFormat = 'hex'} = {}) => {
 	if (typeof buffer === 'string') {
 		buffer = new globalThis.TextEncoder().encode(buffer);
 	}
 
-	// eslint-disable-next-line n/no-unsupported-features/node-builtins
 	const hash = await globalThis.crypto.subtle.digest(algorithm, buffer);
 
 	return outputFormat === 'hex' ? bufferToHex(hash) : hash;

--- a/index.js
+++ b/index.js
@@ -1,16 +1,6 @@
 import {Worker} from 'node:worker_threads';
 import crypto from 'node:crypto';
-
-const bufferToHex = buffer => {
-	const view = new DataView(buffer);
-
-	let hexCodes = '';
-	for (let index = 0; index < view.byteLength; index += 4) {
-		hexCodes += view.getUint32(index).toString(16).padStart(8, '0');
-	}
-
-	return hexCodes;
-};
+import {bufferToHex} from './utilities.js';
 
 let create = algorithm => async (buffer, {outputFormat = 'hex'} = {}) => {
 	const hash = crypto.createHash(algorithm);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,9 @@
 import {expectType} from 'tsd';
 import {
-	sha1, sha256, sha384, sha512,
+	sha1,
+	sha256,
+	sha384,
+	sha512,
 } from './index.js';
 
 expectType<Promise<string>>(sha1('🦄'));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,7 @@
 import {expectType} from 'tsd';
-import {sha1, sha256, sha384, sha512} from './index.js';
+import {
+	sha1, sha256, sha384, sha512,
+} from './index.js';
 
 expectType<Promise<string>>(sha1('🦄'));
 expectType<Promise<ArrayBuffer>>(sha1('🦄', {outputFormat: 'buffer'}));

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"index.js",
 		"index.d.ts",
 		"browser.js",
-		"thread.js"
+		"thread.js",
+		"utilities.js"
 	],
 	"keywords": [
 		"crypto",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
 		"browser"
 	],
 	"devDependencies": {
-		"@sindresorhus/is": "^6.0.1",
-		"ava": "^5.3.1",
+		"@sindresorhus/is": "^7.0.0",
+		"ava": "^6.1.3",
 		"hash.js": "^1.1.7",
-		"tsd": "^0.29.0",
-		"xo": "^0.56.0"
+		"tsd": "^0.31.1",
+		"xo": "^0.59.2"
 	}
 }

--- a/test-browser.js
+++ b/test-browser.js
@@ -1,7 +1,9 @@
 /* eslint-env jasmine */
 import hashjs from 'hash.js';
 import is from '@sindresorhus/is';
-import {sha1, sha256, sha384, sha512} from './browser.js';
+import {
+	sha1, sha256, sha384, sha512,
+} from './browser.js';
 
 const fixture = 'foo bar baz';
 

--- a/test-browser.js
+++ b/test-browser.js
@@ -2,7 +2,10 @@
 import hashjs from 'hash.js';
 import is from '@sindresorhus/is';
 import {
-	sha1, sha256, sha384, sha512,
+	sha1,
+	sha256,
+	sha384,
+	sha512,
 } from './browser.js';
 
 const fixture = 'foo bar baz';

--- a/test.js
+++ b/test.js
@@ -2,7 +2,10 @@ import test from 'ava';
 import hashjs from 'hash.js';
 import is from '@sindresorhus/is';
 import {
-	sha1, sha256, sha384, sha512,
+	sha1,
+	sha256,
+	sha384,
+	sha512,
 } from './index.js';
 
 const fixture = 'foo bar baz';

--- a/test.js
+++ b/test.js
@@ -1,8 +1,9 @@
-import {Buffer} from 'node:buffer';
 import test from 'ava';
 import hashjs from 'hash.js';
 import is from '@sindresorhus/is';
-import {sha1, sha256, sha384, sha512} from './index.js';
+import {
+	sha1, sha256, sha384, sha512,
+} from './index.js';
 
 const fixture = 'foo bar baz';
 
@@ -33,8 +34,7 @@ test('buffer input', async t => {
 
 test('buffer input - ArrayBuffer', async t => {
 	const fixture = 'x';
-	const fixtureBuffer = new ArrayBuffer(Buffer.byteLength(fixture, 'utf8'));
-	Buffer.from(fixtureBuffer).write(fixture, 'utf8');
+	const fixtureBuffer = new TextEncoder().encode(fixture).buffer;
 	t.is(await sha1(fixture), await sha1(fixtureBuffer));
 });
 

--- a/thread.js
+++ b/thread.js
@@ -1,12 +1,10 @@
-import {Buffer} from 'node:buffer';
 import crypto from 'node:crypto';
 import {parentPort} from 'node:worker_threads';
 
-parentPort.on('message', message => {
-	const {algorithm, buffer} = message.value;
+parentPort.on('message', ({id, value: {algorithm, buffer}}) => {
 	const hash = crypto.createHash(algorithm);
-	hash.update(Buffer.from(buffer));
-	const arrayBuffer = hash.digest().buffer;
+	hash.update(new DataView(buffer));
+	const value = hash.digest().buffer;
 	// Transfering buffer here for consistency, but considering buffer size it might be faster to just leave it for copying, needs perf test
-	parentPort.postMessage({id: message.id, value: arrayBuffer}, [arrayBuffer]);
+	parentPort.postMessage({id, value}, [value]);
 });

--- a/utilities.js
+++ b/utilities.js
@@ -1,0 +1,10 @@
+export const bufferToHex = buffer => {
+	const view = new DataView(buffer);
+
+	let hexCodes = '';
+	for (let index = 0; index < view.byteLength; index += 4) {
+		hexCodes += view.getUint32(index).toString(16).padStart(8, '0');
+	}
+
+	return hexCodes;
+};


### PR DESCRIPTION
A rough benchmark of the parallel test running 10000 times instead of 10 yielded a decent improvement:

- new: 76.661ms
- old:  90.661ms

I copied the `bufferToHex` function from browser into the node code to avoid using `Buffer#toString('hex')`

